### PR TITLE
Update n64-gameshark.md

### DIFF
--- a/n64-gameshark.md
+++ b/n64-gameshark.md
@@ -138,9 +138,9 @@ N64 GameSharks can be dumped (read) and reflashed (written) with a [Sanni Cart R
 
 | Filename                                     | Version       | Build timestamp    | #G      | #C       | Clean? |
 |:-------------------------------------------- |:------------- |:------------------ | -------:| --------:|:------:|
-|   [`gs-1.01-19970731-pristine.bin`]          | `v1.01`       | '1997-07-31T13:23' |    15   |     95   | ✅      |
-|   [`gs-1.02-19970801-dirty.bin`]             | `v1.02`       | `1997-08-01T12:50` |    20   |    117   | ❌      |
-|    `gs-1.03-xxxxxxxx.bin`[^v1.0x]            | `v1.03`       | _Unknown_          |     ?   |      ?   | ?      |
+|   [`gs-1.01-19970731-pristine.bin`][]        | `v1.01`       | '1997-07-31T13:23' |    15   |     95   | ✅      |
+|   [`gs-1.02-19970801-dirty.bin`][]           | `v1.02`       | `1997-08-01T12:50` |    20   |    117   | ❌      |
+|   [`gs-1.03-19970808-dirty.bin`][]           | `v1.03`       | '1997-08-08T11:50' |     27  |    202   | ❌      |
 | ~~[`gs-1.04-19970819-corrupt-codes.bin`][]~~ | `v1.04`       | `1997-08-19T10:35` |   ~~2~~ |    ~~3~~ | ❌      |
 |   [`gs-1.04-19970819-valid-codes.bin`][]     | `v1.04`       | `1997-08-19T10:35` |    22   |    142   | ❌      |
 |   [`gs-1.05-19970904-dirty.bin`][]           | `v1.05 (Thu)` | `1997-09-04T16:25` |    23   |    133   | ❌      |
@@ -166,12 +166,12 @@ N64 GameSharks can be dumped (read) and reflashed (written) with a [Sanni Cart R
 |   [`gspro-3.30-20000404-pristine.bin`][]     | `v3.30 (Apr)` | `2000-04-04T15:56` |   188   |   2093   | ⭐️      |
 |   [`perfect_trainer-1.0b-20030618.bin`][]    | `v1.0b`       | `2003-06-18T00:00` |  _N/A_  |   _N/A_  | _N/A_  |
 
-[^v1.0x]: `v1.03` supposedly exists according to a [Krikzz forum post](https://krikzz.com/forum/index.php?topic=6585.0), [Reddit post](https://www.reddit.com/r/Roms/comments/dui43a/n64_gameshark_v32/), and [vspolaris article](https://vspolaris.tistory.com/24), but we have not yet found any conclusive evidence of a `v1.03` cart.
 [^v2.20]: `v2.20` is [**confirmed** to exist](https://imgur.com/2Sa2NaR), but we have not yet acquired a cart to dump its firmware.
 [^v2.40]: `v2.40` supposedly exists according to the official [N64 GameShark Version Compatibility table](https://web.archive.org/web/20010720115238/http://www.gameshark.com/static/about_faq_version_n64.html), but we have not yet found any conclusive evidence of a `v2.40` cart.
 
 [`gs-1.01-19970731-pristine.bin`]:         /n64/firmware/gs-1.01-19970731-Pristine.bin
 [`gs-1.02-19970801-dirty.bin`]:         /n64/firmware/gs-1.02-19970801-dirty.bin
+[`gs-1.03-19970808-dirty.bin`]:         /n64/firmware/gs-1.03-19970808-dirty.bin
 [`gs-1.04-19970819-corrupt-codes.bin`]: /n64/firmware/gs-1.04-19970819-corrupt-codes.bin
 [`gs-1.04-19970819-valid-codes.bin`]:   /n64/firmware/gs-1.04-19970819-valid-codes.bin
 [`gs-1.05-19970904-dirty.bin`]:         /n64/firmware/gs-1.05-19970904-dirty.bin


### PR DESCRIPTION
Update to include and list 1.03 Gameshark Firmware